### PR TITLE
updated trivy scan issue

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /app
 
 COPY requirements.txt constraints.txt ./
 
-RUN pip install --no-cache-dir --upgrade pip setuptools \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir --upgrade pip setuptools \
     && pip install --no-cache-dir --upgrade --force-reinstall -c constraints.txt wheel jaraco.context \
     && pip install --no-cache-dir -r requirements.txt -c constraints.txt
 


### PR DESCRIPTION
twin_api:latest (debian 13.3)
=============================
Total: 2 (HIGH: 2, CRITICAL: 0)
